### PR TITLE
Add unit tests of the test suite, fix run test XPath exception

### DIFF
--- a/src/main/java/org/opengis/cite/om20/level1/DataFixture.java
+++ b/src/main/java/org/opengis/cite/om20/level1/DataFixture.java
@@ -575,7 +575,7 @@ public class DataFixture {
 		String context = String.format("//om:OM_Observation[om:type/@xlink:href='%s']", href);
 		int count_observation = Integer.parseInt((CheckXPath2(String.format("count(%s)", context))));
 		for (int i = 1; i <= count_observation; i++) {
-			results.add(CheckXPath2(String.format("(%s/om:result/text())[%s] castable as xs:integer)", context, i)));
+			results.add(CheckXPath2(String.format("(%s/om:result/text())[%s] castable as xs:integer", context, i)));
 		}
 		return results;
 	}

--- a/src/test/java/org/opengis/cite/om20/VerifyTestNGController.java
+++ b/src/test/java/org/opengis/cite/om20/VerifyTestNGController.java
@@ -53,9 +53,9 @@ public class VerifyTestNGController {
                 "/test-run-props.xml"));
     }
 
-    //@Test
+    @Test
     public void doTestRun() throws Exception {
-    	URL testSubject = getClass().getResource("/atom-feed-2.xml");
+    	URL testSubject = getClass().getResource("/CountObservation.xml");
         this.testRunProps.setProperty(TestRunArg.IUT.toString(), testSubject
                 .toURI().toString());
         ByteArrayOutputStream outStream = new ByteArrayOutputStream(1024);
@@ -68,6 +68,6 @@ public class VerifyTestNGController {
         XdmValue failed = XMLUtils.evaluateXPath2(results, xpath, null);
         int numFailed = Integer.parseInt(failed.getUnderlyingValue()
                 .getStringValue());
-        assertEquals("Unexpected number of fail verdicts.", 3, numFailed);
+        assertEquals("Unexpected number of fail verdicts.", 0, numFailed);
     }
 }


### PR DESCRIPTION
Add a basic unit test for testing the TestNGController with an example file. Also fixed the XPath exception when running the test.