### PR TITLE
Set maven-fluido-skin to version 2.0.1, restore deleted resources

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -158,6 +158,11 @@
           <include>**/*.xsd</include>
         </includes>
       </resource>
+      <resource>
+        <directory>src/main/javadoc</directory>
+        <filtering>true</filtering>
+        <targetPath>doc/${ets-code}/${project.version}</targetPath>
+      </resource>
     </resources>
   </build>
 

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -7,7 +7,7 @@
   <skin>
     <groupId>org.apache.maven.skins</groupId>
     <artifactId>maven-fluido-skin</artifactId>
-    <version>1.5</version>
+    <version>2.0.1</version>
   </skin>
   <custom>
     <fluidoSkin>


### PR DESCRIPTION
Fix maven-fluido-skin version an restore deleted resources (https://github.com/opengeospatial/ets-omxml20/commit/928673f1e293936cc6c9e956bcdccaa1cf3ceaf0), context in https://github.com/opengeospatial/cite-private/issues/395.